### PR TITLE
Adding the concept of ICD 10 billable to the disease list

### DIFF
--- a/sparql/matrix-disease-list-filters.sparql
+++ b/sparql/matrix-disease-list-filters.sparql
@@ -25,6 +25,7 @@ SELECT DISTINCT ?category_class ?label ?definition ?synonyms ?subsets ?crossrefe
   (IF(SUM(IF(?filter_icd_category = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_icd_category)
   (IF(SUM(IF(?filter_icd_chapter_code = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_icd_chapter_code)
   (IF(SUM(IF(?filter_icd_chapter_header = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_icd_chapter_header)
+  (IF(SUM(IF(?filter_icd_billable = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_icd_billable)
 
 WHERE
 {
@@ -206,6 +207,14 @@ WHERE
     }
     BIND("TRUE" as ?filter_leaf_direct_parent)
   }
+
+   # Filter: Disease that correspond to billable ICD10 codes
+   # Example: https://icd.codes/icd10cm/R412
+  
+   OPTIONAL {
+     ?category_class oio:inSubset <http://purl.obolibrary.org/obo/mondo#icd10_billable> .
+     BIND("TRUE" as ?filter_icd_billable)
+   }
   
   # Filter: Disease corresponds to an ICD-10 category
   OPTIONAL {


### PR DESCRIPTION
This does not currently make a difference to the filtering code, but it may in the future. I think it is a good thing to have in the back pocket.

Resolves #9 

### Summary

This PR

- Introduces the idea of a "icd10 billable subset". It downloads a list of billable ICD 10 codes from CMS, then annotatoes all classes with that subset
- I chose not to actual _use_ that filter for now, as it _does not make a difference_ compared to the current approach
- It may, however, become a useful concept in the future.

### Checklist

- [X] List has been rebuilt if changes are made to the list contents

### General SOP for PRs

- The person that creates the PR should assign themselves
- Only the assigned person is allowed to merge a PR - not the reviewers
- Every PR that alters the disease list should be reviewed by at least 2 people from the disease list team
