### PR TITLE
Add alkaptonuria (MONDO:0008753) review to disease list

### DIFF
--- a/src/included-diseases.robot.tsv
+++ b/src/included-diseases.robot.tsv
@@ -289,3 +289,4 @@ MONDO:1040003	KCND2-related neurodevelopmental disorder with or without seizures
 MONDO:1040006	CTR9-related neurodevelopmental disorder	obo:mondo#matrix_included	https://orcid.org/0000-0003-2955-4640	
 MONDO:1040008	CAMK2D-related neurodevelopmental disorder and dilated cardiomyopathy	obo:mondo#matrix_included	https://orcid.org/0000-0003-2955-4640	
 MONDO:1030016	22q-related schwannomatosis	obo:mondo#matrix_included	https://orcid.org/0000-0003-2955-4640	
+MONDO:0008753	alkaptonuria	obo:mondo#matrix_included	https://orcid.org/0000-0003-2955-4640	


### PR DESCRIPTION
alkaptonuria (MONDO:0008753) is already in the [last disease list](https://github.com/everycure-org/matrix-disease-list/releases/tag/2024-12-20), but since we have a medical review I added it to the set of reviewed diseases just the same.

Resolves #26. 

### Summary

This PR

- Adds @elliottsharp review of MONDO:0008753 to the expert curated inclusions

### Checklist

- [] ~~List has been rebuilt if changes are made to the list contents~~

### General SOP for PRs

- The person that creates the PR should assign themselves
- Only the assigned person is allowed to merge a PR - not the reviewers
- Every PR that alters the disease list should be reviewed by at least 2 people from the disease list team
