### PR TITLE
Adding filter for pathway defects

### DIFF
--- a/sparql/matrix-disease-list-filters.sparql
+++ b/sparql/matrix-disease-list-filters.sparql
@@ -27,6 +27,7 @@ SELECT DISTINCT ?category_class ?label ?definition ?synonyms ?subsets ?crossrefe
   (IF(SUM(IF(?filter_icd_chapter_header = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_icd_chapter_header)
   (IF(SUM(IF(?filter_icd_billable = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_icd_billable)
   (IF(SUM(IF(?filter_mondo_subtype = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_mondo_subtype)
+  (IF(SUM(IF(?filter_pathway_defect = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_pathway_defect)
   (IF(SUM(IF(?filter_susceptibility = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_susceptibility)
   (IF(SUM(IF(?filter_paraphilic = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_paraphilic)
   (IF(SUM(IF(?filter_acquired = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_acquired)
@@ -157,6 +158,13 @@ WHERE
   OPTIONAL {
     ?category_class oio:inSubset <http://purl.obolibrary.org/obo/mondo#mondo_subtype> .
     BIND("TRUE" as ?filter_mondo_subtype)
+  }
+
+  # FILTER if the disease corresponds to a pathway defect
+  # https://github.com/everycure-org/matrix-disease-list/issues/51
+  OPTIONAL {
+    ?category_class oio:inSubset <http://purl.obolibrary.org/obo/mondo#pathway_defect> .
+    BIND("TRUE" as ?filter_pathway_defect)
   }
   
   # Filter: Disease is a designated grouping class in Mondo

--- a/src/excluded-diseases.robot.tsv
+++ b/src/excluded-diseases.robot.tsv
@@ -81,3 +81,7 @@ MONDO:0006773	gonadal tissue neoplasm	obo:mondo#matrix_excluded|obo:mondo#matrix
 MONDO:0003111	gastric neuroendocrine neoplasm	obo:mondo#matrix_excluded|obo:mondo#matrix_grouping	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/52
 MONDO:0002101	facial nerve neoplasm	obo:mondo#matrix_excluded|obo:mondo#matrix_grouping	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/52
 MONDO:0000744	lung abscess	obo:mondo#matrix_excluded|obo:mondo#matrix_grouping	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/52
+MONDO:0024632	defective phagocytic cell opsonization	obo:mondo#matrix_excluded|obo:mondo#pathway_defect	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/51
+MONDO:0024630	defective phagocytic cell chemotaxis	obo:mondo#matrix_excluded|obo:mondo#pathway_defect	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/51
+MONDO:0009472	acetylation, slow	obo:mondo#matrix_excluded|obo:mondo#pathway_defect	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/51
+MONDO:0001962	abnormality of glucagon secretion	obo:mondo#matrix_excluded|obo:mondo#pathway_defect	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/51

--- a/src/excluded-diseases.robot.tsv
+++ b/src/excluded-diseases.robot.tsv
@@ -98,4 +98,3 @@ MONDO:0024632	defective phagocytic cell opsonization	obo:mondo#matrix_excluded|o
 MONDO:0024630	defective phagocytic cell chemotaxis	obo:mondo#matrix_excluded|obo:mondo#pathway_defect	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/51
 MONDO:0009472	acetylation, slow	obo:mondo#matrix_excluded|obo:mondo#pathway_defect	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/51
 MONDO:0001962	abnormality of glucagon secretion	obo:mondo#matrix_excluded|obo:mondo#pathway_defect	https://orcid.org/0000-0003-2955-4640	https://github.com/everycure-org/matrix-disease-list/issues/51
-


### PR DESCRIPTION
Currently pathways defects need to be manually curated. If you have a smart idea an how we could recognise these kinds of diseases computationally, please open a new isseu.

Resolves #51 

### Summary

This PR

- tags pathway defects
- adds a filter for pathway defects

### Checklist

- [] List has been rebuilt if changes are made to the list contents

### General SOP for PRs

- The person that creates the PR should assign themselves
- Only the assigned person is allowed to merge a PR - not the reviewers
- Every PR that alters the disease list should be reviewed by at least 2 people from the disease list team
