### PR TITLE
Big refactor of disease list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ tmp/icd10-cm-billable.template.tsv: tmp/icd10-cm-codes.xlsx tmp/mondo.sssom.tsv
 		-o $@
 
 tmp/llm-based-disease-groupings.template.tsv: llm-disease-categorization/data/03_primary/disease_categories.tsv
-	python scripts/matrix-disease-list.py format-llm-disease-categorization -i $< -o $@ -c "https://orcid.org/0000-0002-4299-3501"
+	python scripts/matrix-disease-list.py format-llm-disease-categorization -i llm-disease-categorization/data/03_primary/disease_categories.tsv -o $@ -c "https://orcid.org/0000-0002-4299-3501"
 
 tmp/mondo-labels.tsv: tmp/mondo.owl
 	$(ROBOT) export -i tmp/mondo.owl -f tsv --header "ID|LABEL" --export $@

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ matrix-disease-list.tsv: matrix-disease-list-unfiltered.tsv scripts/matrix-disea
 .PRECIOUS: matrix-disease-list.tsv
 
 # ROBOT template with the disease list designations added as subset declarations
-tmp/matrix-list-designations.robot.tsv: matrix-disease-list-unfiltered-processed.tsv
+tmp/matrix-list-designations.robot.tsv: matrix-disease-list-unfiltered-processed.tsv matrix-disease-list.tsv
 	python scripts/matrix-disease-list.py create-template-from-matrix-disease-list -i $< -o $@
 .PRECIOUS: tmp/matrix-list-designations.robot.tsv
 

--- a/scripts/matrix-disease-list.py
+++ b/scripts/matrix-disease-list.py
@@ -282,6 +282,11 @@ def create_matrix_disease_list(input_file, subtype_counts_tsv, output_included_d
     df_disease_groupings_pivot.rename(columns=lambda x: f"g_{x}" if x != 'category_class' else x, inplace=True)
     
     # Merge df_disease_groupings_pivot into df_matrix_disease_filter_modified
+    
+    # As per convention, rewrite filter columns to is_ 
+    # https://github.com/everycure-org/matrix-disease-list/issues/75
+    df_matrix_disease_filter_modified.rename(columns=lambda x: re.sub(r'^f_', 'is_', x) if x.startswith("f_") else x, inplace=True)
+    
     df_matrix_disease_filter_modified = df_matrix_disease_filter_modified.merge(df_disease_groupings_pivot, on='category_class', how='left')
     df_matrix_disease_filter_modified = df_matrix_disease_filter_modified.merge(df_subtype_counts[["subset_id", "subset_group_id", "subset_group_label", "other_subsets_count"]], left_on='category_class', right_on="subset_id", how='left')
     

--- a/scripts/matrix-disease-list.py
+++ b/scripts/matrix-disease-list.py
@@ -255,8 +255,8 @@ def create_matrix_disease_list(input_file, subtype_counts_tsv, output_included_d
         df_excluded_diseases.to_csv(output_excluded_diseases, sep='\t', index=False)
         click.echo(f"Excluded diseases written to {output_excluded_diseases}")
     
-    curated_disease_groupings = ["harrisons_view", "matrix_txgnn_grouping", "mondo_top_grouping"]
-    llm_disease_groupings = [ "matrix_llm__medical_specialization",	"matrix_llm__txgnn", "matrix_llm__anatomical", "matrix_llm__is_pathogen_caused", "matrix_llm__is_cancer", "matrix_llm__is_glucose_dysfunction", "matrix_llm__tag_existing_treatment", "matrix_llm__tag_qaly_lost"]
+    curated_disease_groupings = ["harrisons_view", "mondo_txgnn", "mondo_top_grouping"]
+    llm_disease_groupings = [ "medical_specialization",	"txgnn", "anatomical", "is_pathogen_caused", "is_cancer", "is_glucose_dysfunction", "tag_existing_treatment", "tag_qaly_lost"]
     disease_groupings = curated_disease_groupings + llm_disease_groupings
     df_disease_groupings = df_matrix_disease_filter_modified[["category_class", "label", "subsets"]]
     
@@ -273,7 +273,7 @@ def create_matrix_disease_list(input_file, subtype_counts_tsv, output_included_d
     
     if output_disease_groupings:
         df_disease_groupings_pivot.to_csv(output_disease_groupings, sep='\t', index=False)
-        click.echo(f"Disease groupinhs written to {output_disease_groupings}")
+        click.echo(f"Disease groupings written to {output_disease_groupings}")
     
     # Remove label column from df_disease_groupings_pivot
     df_disease_groupings_pivot.drop(columns=['label'], inplace=True)
@@ -355,9 +355,14 @@ def format_llm_disease_categorization(input_file, output_file, contributor, repa
 
         # Process all columns after the first one as subsets
         for column_name in df.columns[1:]:
+            if column_name.startswith('f_'):
+                # Comment to self: this if clause is probably no longer needed
+                continue
             col = column_name.lower()
-            subset_prefix = f'obo:mondo#matrix_llm__{col}'
-            subset_prefix_member = f'obo:mondo#matrix_llm__{col}_member'
+            subset_prefix = f'obo:mondo#{col}'
+            subset_prefix_member = f'obo:mondo#{col}_member'
+            
+            specific_subsets = []
             if isinstance(row[column_name], str):
                 specific_subsets = row[column_name].strip().split('|')
             

--- a/scripts/matrix-disease-list.py
+++ b/scripts/matrix-disease-list.py
@@ -284,6 +284,9 @@ def create_matrix_disease_list(input_file, subtype_counts_tsv, output_included_d
     # Merge df_disease_groupings_pivot into df_matrix_disease_filter_modified
     df_matrix_disease_filter_modified = df_matrix_disease_filter_modified.merge(df_disease_groupings_pivot, on='category_class', how='left')
     df_matrix_disease_filter_modified = df_matrix_disease_filter_modified.merge(df_subtype_counts[["subset_id", "subset_group_id", "subset_group_label", "other_subsets_count"]], left_on='category_class', right_on="subset_id", how='left')
+    
+    # Remove subset_id column after merge
+    df_matrix_disease_filter_modified.drop(columns=['subset_id'], inplace=True)
 
     if output_unfiltered_diseases_processed:
         df_matrix_disease_filter_modified.to_csv(output_unfiltered_diseases_processed, sep='\t', index=False)

--- a/scripts/matrix-disease-list.py
+++ b/scripts/matrix-disease-list.py
@@ -277,10 +277,7 @@ def create_matrix_disease_list(input_file, subtype_counts_tsv, output_included_d
     
     # Remove label column from df_disease_groupings_pivot
     df_disease_groupings_pivot.drop(columns=['label'], inplace=True)
-    
-    # Prepend "g_" to all column names corresponding to groups
-    df_disease_groupings_pivot.rename(columns=lambda x: f"g_{x}" if x != 'category_class' else x, inplace=True)
-    
+       
     # Merge df_disease_groupings_pivot into df_matrix_disease_filter_modified
     
     # As per convention, rewrite filter columns to is_ 

--- a/scripts/matrix-disease-list.py
+++ b/scripts/matrix-disease-list.py
@@ -175,13 +175,18 @@ def extract_groupings(subsets, groupings):
     
     if subsets:
         for subset in subsets.split(";"):
+            subset = subset.strip()
             for grouping in groupings:
-                if grouping in subset:
-                    # Extract the specific part after the grouping
+                if subset.startswith(f"mondo:{grouping}"):
                     subset_tag = subset.replace("mondo:","").replace(grouping,"").replace(" ","").strip("_")
-                    if subset_tag != "member":
-                        result[grouping].append(subset_tag)
-    return {key: "|".join(values) if values else "" for key, values in result.items()}
+                    if (subset_tag != "member") and (subset_tag != ""):
+                        result[grouping].append(subset_tag.replace("|",""))
+    
+    # This looks very complex: if there are multiple values, we join them with a pipe, but we exclude "other" in this case
+    return {
+        key: "|".join([v for v in values if v != "other"] if len(values) > 1 else values) if values else ""
+        for key, values in result.items()
+    }
 
 
 @cli.command()

--- a/sparql/disease-groupings-other.ru
+++ b/sparql/disease-groupings-other.ru
@@ -7,17 +7,17 @@ INSERT {
 }
 WHERE {
   VALUES ?subset { 
-    <http://purl.obolibrary.org/obo/mondo#matrix_txgnn_grouping>
+    <http://purl.obolibrary.org/obo/mondo#mondo_txgnn>
     <http://purl.obolibrary.org/obo/mondo#harrisons_view>
     <http://purl.obolibrary.org/obo/mondo#mondo_top_grouping>
-    <http://purl.obolibrary.org/obo/mondo#matrix_llm__txgnn>
-    <http://purl.obolibrary.org/obo/mondo#matrix_llm__anatomical>
-    <http://purl.obolibrary.org/obo/mondo#matrix_llm__medical_specialization>
-    <http://purl.obolibrary.org/obo/mondo#matrix_llm__is_pathogen_caused>
-    <http://purl.obolibrary.org/obo/mondo#matrix_llm__is_cancer>
-    <http://purl.obolibrary.org/obo/mondo#matrix_llm__is_glucose_dysfunction>
-    <http://purl.obolibrary.org/obo/mondo#matrix_llm__tag_existing_treatment>
-    <http://purl.obolibrary.org/obo/mondo#matrix_llm__tag_qualy_lost>
+    <http://purl.obolibrary.org/obo/mondo#txgnn>
+    <http://purl.obolibrary.org/obo/mondo#anatomical>
+    <http://purl.obolibrary.org/obo/mondo#medical_specialization>
+    <http://purl.obolibrary.org/obo/mondo#is_pathogen_caused>
+    <http://purl.obolibrary.org/obo/mondo#is_cancer>
+    <http://purl.obolibrary.org/obo/mondo#is_glucose_dysfunction>
+    <http://purl.obolibrary.org/obo/mondo#tag_existing_treatment>
+    <http://purl.obolibrary.org/obo/mondo#tag_qualy_lost>
   }
   ?subject rdfs:subClassOf+ <http://purl.obolibrary.org/obo/MONDO_0700096> .
   

--- a/sparql/downfill-disease-groupings.ru
+++ b/sparql/downfill-disease-groupings.ru
@@ -8,7 +8,7 @@ INSERT {
 }
 WHERE {
     VALUES ?subset { 
-      <http://purl.obolibrary.org/obo/mondo#matrix_txgnn_grouping> 
+      <http://purl.obolibrary.org/obo/mondo#mondo_txgnn> 
       <http://purl.obolibrary.org/obo/mondo#harrisons_view>
       <http://purl.obolibrary.org/obo/mondo#mondo_top_grouping> 
       }

--- a/src/grouping-diseases.robot.tsv
+++ b/src/grouping-diseases.robot.tsv
@@ -1,12 +1,12 @@
 ID	LABEL	SUBSET	CONTRIBUTOR	COMMENT
 ID		AI oboInOwl:inSubset	>AI dc:contributor SPLIT=|	
-MONDO:0002025	psychiatric disorder	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Mental health disorders
-MONDO:0002280	anemia	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Anaemia
-MONDO:0004995	cardiovascular disorder	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Cardiovascular disorders
-MONDO:0005015	diabetes mellitus	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Diabetes related diseases (MONDO:0005015 may be a bit more specific)
-MONDO:0005066	metabolic disease	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Metabolic disorders
-MONDO:0005151	endocrine system disorder	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Hormonal diseases (MONDO:0005015 may be a bit more specific)
-MONDO:0005550	infectious disease	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Infectious diseases/pathogen caused diseases (MONDO:0005015 may be a bit more specific, pathogen could be anything)
-MONDO:0005559	neurodegenerative disease	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Neurodegenerative diseases
-MONDO:0007179	autoimmune disease	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Auto-immune diseases
-MONDO:0045024	cancer or benign tumor	obo:mondo#matrix_txgnn_grouping	https://orcid.org/0000-0002-7356-1779	Original: Cancerous diseases
+MONDO:0002025	psychiatric disorder	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Mental health disorders
+MONDO:0002280	anemia	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Anaemia
+MONDO:0004995	cardiovascular disorder	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Cardiovascular disorders
+MONDO:0005015	diabetes mellitus	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Diabetes related diseases (MONDO:0005015 may be a bit more specific)
+MONDO:0005066	metabolic disease	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Metabolic disorders
+MONDO:0005151	endocrine system disorder	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Hormonal diseases (MONDO:0005015 may be a bit more specific)
+MONDO:0005550	infectious disease	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Infectious diseases/pathogen caused diseases (MONDO:0005015 may be a bit more specific, pathogen could be anything)
+MONDO:0005559	neurodegenerative disease	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Neurodegenerative diseases
+MONDO:0007179	autoimmune disease	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Auto-immune diseases
+MONDO:0045024	cancer or benign tumor	obo:mondo#mondo_txgnn	https://orcid.org/0000-0002-7356-1779	Original: Cancerous diseases


### PR DESCRIPTION
Resolves #74 #72 and a few other unspoken issues.

### Summary

This PR

- Renames all the columns to a nice, use friendly standard (removing implementation details like g_, f_ and similar)
- Removes a redundant column from the list (subset_id)
- Makes sure boolean columns are truly boolean, replacing not truthy values with FALSE
- Fixing a number of bugs with the disease tagging

### Checklist

- [] List has been rebuilt if changes are made to the list contents

### General SOP for PRs

- The person that creates the PR should assign themselves
- Only the assigned person is allowed to merge a PR - not the reviewers
- Every PR that alters the disease list should be reviewed by at least 2 people from the disease list team
