### PR TITLE
Adding misc filters and descendant counting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,19 @@ matrix-disease-list-unfiltered.tsv: tmp/mondo-with-manually-curated-subsets.owl 
 	sed -i 's/>//g' $@
 .PRECIOUS: matrix-disease-list-unfiltered.tsv
 
+matrix-disease-list-metrics.tsv: tmp/mondo-with-manually-curated-subsets.owl sparql/matrix-disease-list-metrics.sparql
+	robot query -i $< -f tsv --query sparql/matrix-disease-list-metrics.sparql $@
+	sed -i 's/[?]//g' $@
+	sed -i 's/<http:[/][/]purl[.]obolibrary[.]org[/]obo[/]MONDO_/MONDO:/g' $@
+	sed -i 's/http:[/][/]purl[.]obolibrary[.]org[/]obo[/]mondo#/mondo:/g' $@
+	sed -i 's/>//g' $@
+.PRECIOUS: matrix-disease-list-metrics.tsv
+
 # The final MATRIX disease list
-matrix-disease-list.tsv: matrix-disease-list-unfiltered.tsv scripts/matrix-disease-list.py
+matrix-disease-list.tsv: matrix-disease-list-unfiltered.tsv matrix-disease-list-metrics.tsv scripts/matrix-disease-list.py
 	pip install -r requirements.txt --break-system-packages
 	python scripts/matrix-disease-list.py create-matrix-disease-list -i matrix-disease-list-unfiltered.tsv \
+		-m matrix-disease-list-metrics.tsv \
 		--subtype-counts-tsv tmp/subtype-counts.tsv \
 		-o matrix-disease-list.tsv \
 		-e matrix-excluded-diseases-list.tsv \

--- a/sparql/matrix-disease-list-filters.sparql
+++ b/sparql/matrix-disease-list-filters.sparql
@@ -30,6 +30,11 @@ SELECT DISTINCT ?category_class ?label ?definition ?synonyms ?subsets ?crossrefe
   (IF(SUM(IF(?filter_pathway_defect = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_pathway_defect)
   (IF(SUM(IF(?filter_susceptibility = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_susceptibility)
   (IF(SUM(IF(?filter_paraphilic = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_paraphilic)
+  (IF(SUM(IF(?filter_inflammatory = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_inflammatory)
+  (IF(SUM(IF(?filter_cancer_or_benign_tumor = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_cancer_or_benign_tumor)
+  (IF(SUM(IF(?filter_cardiovascular = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_cardiovascular)
+  (IF(SUM(IF(?filter_heart_disorder = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_filter_heart_disorder)
+  (IF(SUM(IF(?filter_psychiatric = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_psychiatric)
   (IF(SUM(IF(?filter_acquired = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_acquired)
   (IF(SUM(IF(?filter_andor = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_andor)
   (IF(SUM(IF(?filter_withorwithout = "TRUE", 1, 0)) > 0, "TRUE", "") AS ?f_withorwithout)
@@ -129,6 +134,41 @@ WHERE
   OPTIONAL {
     ?category_class rdfs:subClassOf* MONDO:0000596 .
     BIND("TRUE" as ?filter_paraphilic)
+  }
+
+  # FILTER if the disease corresponds to a cardiovascular disorder
+  # https://github.com/everycure-org/matrix-disease-list/issues/90
+  OPTIONAL {
+    ?category_class rdfs:subClassOf* MONDO:0004995 .
+    BIND("TRUE" as ?filter_cardiovascular)
+  }
+
+  # FILTER if the disease corresponds to a heart disorder
+  # https://github.com/everycure-org/matrix-disease-list/issues/90
+  OPTIONAL {
+    ?category_class rdfs:subClassOf* MONDO:0005267 .
+    BIND("TRUE" as ?filter_heart_disorder)
+  }
+  
+  # FILTER if the disease corresponds to a inflammatory disease
+  # https://github.com/everycure-org/matrix-disease-list/issues/89
+  OPTIONAL {
+    ?category_class rdfs:subClassOf* MONDO:0021166 .
+    BIND("TRUE" as ?filter_inflammatory)
+  }
+
+  # FILTER if the disease corresponds to a psychiatric disorder
+  # https://github.com/everycure-org/matrix-disease-list/issues/88
+  OPTIONAL {
+    ?category_class rdfs:subClassOf* MONDO:0002025 .
+    BIND("TRUE" as ?filter_psychiatric)
+  }
+
+  # FILTER if the disease corresponds to a cancer
+  # https://github.com/everycure-org/matrix-disease-list/issues/87
+  OPTIONAL {
+    ?category_class rdfs:subClassOf* MONDO:0045024 .
+    BIND("TRUE" as ?filter_cancer_or_benign_tumor)
   }
 
 

--- a/sparql/matrix-disease-list-metrics.sparql
+++ b/sparql/matrix-disease-list-metrics.sparql
@@ -1,0 +1,30 @@
+PREFIX IAO: <http://purl.obolibrary.org/obo/IAO_>
+PREFIX MONDO: <http://purl.obolibrary.org/obo/MONDO_>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX def: <http://purl.obolibrary.org/obo/IAO_0000115>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX mondo: <http://purl.obolibrary.org/obo/mondo#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT 
+  ?category_class
+  (COUNT(DISTINCT ?decendant_disease) AS ?count_descendants)
+WHERE
+{
+  # We are only looking for classes that are specifically human diseases.
+  ?category_class rdfs:subClassOf* MONDO:0700096 .
+
+  ########################
+  #### Metadata ##########
+  ########################
+
+  OPTIONAL {
+    ?decendant_disease rdfs:subClassOf+ ?category_class .
+  }
+
+  FILTER( !isBlank(?category_class) && STRSTARTS(str(?category_class), "http://purl.obolibrary.org/obo/MONDO_"))
+} 
+GROUP BY ?category_class
+ORDER BY DESC(?category_class)


### PR DESCRIPTION
Fixes #92 #87 #88 #89 #90 

### Summary

This PR

- Added a dozen or so new matching patterns
- Added a new requirement that the matched disease is indeed a parent (sometimes a match was accidental, and the supposed supertype was indeed not one)
- Reworked the matching pipeline to be a bit faster and more accurate (it missed a few subtypes in now catches, for example because I added “lower casing” to the matching pipeline)
- Added a new subsystem for efficiently extracting ontology metrics (out of which “descendant counting” was the first)
- Adds four new disease level filters

### Checklist

- [] List has been rebuilt if changes are made to the list contents

### General SOP for PRs

- The person that creates the PR should assign themselves
- Only the assigned person is allowed to merge a PR - not the reviewers
- Every PR that alters the disease list should be reviewed by at least 2 people from the disease list team
