### PR TITLE
Add tables with information to obsoletion to disease list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ matrix-disease-list.xlsx
 mondo-with-filter-designations.owl
 .DS_Store
 /kedro_env
+mondo-obsoletes.tsv
+mondo-obsoletion-candidates.tsv

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ ASSETS=matrix-disease-list.tsv \
 	matrix-excluded-diseases-list.tsv \
 	matrix-disease-groupings.tsv \
 	mondo-metadata.tsv \
-	mondo-with-filter-designations.owl
+	mondo-with-filter-designations.owl \
+	mondo-obsoletes.sparql \
+	mondo-obsoletion-candidates.tsv
 
 all: $(ASSETS)
 
@@ -115,6 +117,19 @@ mondo-metadata.tsv: tmp/mondo.owl sparql/ontology-metadata.sparql
 	sed -i 's/<//g' $@
 	sed -i 's/>//g' $@
 .PRECIOUS: mondo-metadata.tsv
+
+mondo-obsoletion-candidates.tsv:
+	wget "https://raw.githubusercontent.com/monarch-initiative/mondo/refs/heads/master/src/ontology/reports/mondo_obsoletioncandidates.tsv" -O $@
+.PRECIOUS: mondo-obsoletion-candidates.tsv
+
+mondo-obsoletes.tsv: #tmp/mondo.owl sparql/mondo-obsoletes.sparql
+	$(ROBOT) query -i tmp/mondo.owl -f tsv --query sparql/mondo-obsoletes.sparql $@
+	sed -i 's/[?]//g' $@
+	sed -i 's/<//g' $@
+	sed -i 's/>//g' $@
+	sed -i 's/"//g' $@
+	sed -i 's|http://purl.obolibrary.org/obo/MONDO_|MONDO:|g' "$@"
+.PRECIOUS: mondo-obsoletes.tsv
 
 # The unfiltered MATRIX disease list, including the filtering features
 matrix-disease-list-unfiltered.tsv: tmp/mondo-with-manually-curated-subsets.owl sparql/matrix-disease-list-filters.sparql

--- a/sparql/mondo-obsoletes.sparql
+++ b/sparql/mondo-obsoletes.sparql
@@ -1,0 +1,31 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX IAO: <http://purl.obolibrary.org/obo/IAO_>
+
+SELECT
+    ?cls
+    ?label
+    ?deprecated
+    (GROUP_CONCAT(DISTINCT STR(?repl); separator="|") AS ?replacements)
+    (GROUP_CONCAT(DISTINCT STR(?cons); separator="|") AS ?considers)
+WHERE {
+    ?cls a owl:Class .
+    FILTER(STRSTARTS(STR(?cls), "http://purl.obolibrary.org/obo/MONDO_"))
+
+    OPTIONAL { ?cls rdfs:label ?label. }
+
+    # common OBO annotation properties for replacements / considers
+    OPTIONAL { ?cls IAO:0100001 ?repl. }
+    OPTIONAL { ?cls oboInOwl:consider ?cons. }
+
+    # detect obsoletion via owl:deprecated = true (robust to literal forms)
+    OPTIONAL { ?cls owl:deprecated ?deprecated. }
+    FILTER(BOUND(?deprecated) &&
+                 ( ?deprecated = true
+                     || STR(?deprecated) = "true"
+                     || ?deprecated = "true"^^xsd:boolean ))
+}
+GROUP BY ?cls ?label ?deprecated
+ORDER BY ?cls


### PR DESCRIPTION
Resolves https://linear.app/everycure/issue/XDATA-246/add-file-of-obsolete-diseases-to-upcoming-release.

### Summary

This PR

- Adds two new tables to the release
- The mondo-obsoletes.tsv asset contains all obsoleted classes in Mondo with their correct replacements (if there are none, then sometimes you can find a "similar class" in the column called "consider"
- The mondo-obsoletion-candidates.tsv asset contains all diseases in Mondo currently flagged for obsoletion. Adding these to the med team SOP can potentially safe time and help dealing with obsoletions in advance rather than retrospectively

### Checklist

- [X] List has been rebuilt if changes are made to the list contents

### General SOP for PRs

- The person that creates the PR should assign themselves
- Only the assigned person is allowed to merge a PR - not the reviewers
- Every PR that alters the disease list should be reviewed by at least 2 people from the disease list team
